### PR TITLE
Remove obsolete comment in Fechar

### DIFF
--- a/src/Notificador/FMX.uNotificador.pas
+++ b/src/Notificador/FMX.uNotificador.pas
@@ -244,7 +244,6 @@ procedure TNotificador.Fechar(Sender: TObject);
 begin
   RemoverDaListaNotificadores;
   LimparComponentes;
-  //destroy;
 end;
 
 procedure TNotificador.ConfigurarListra;


### PR DESCRIPTION
## Summary
- tidy `TNotificador.Fechar` by removing commented `destroy` call

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849e61e376483279cd5607b529f7194