### PR TITLE
Call LimparComponentes in destructors

### DIFF
--- a/src/Notificador/FMX.uNotificador.pas
+++ b/src/Notificador/FMX.uNotificador.pas
@@ -98,6 +98,7 @@ end;
 destructor TNotificador.Destroy;
 begin
 
+  LimparComponentes;
   inherited;
 end;
 

--- a/src/Notificador/VCL.uNotificador.pas
+++ b/src/Notificador/VCL.uNotificador.pas
@@ -98,6 +98,7 @@ end;
 destructor TNotificador.Destroy;
 begin
 
+  LimparComponentes;
   inherited;
 end;
 


### PR DESCRIPTION
## Summary
- ensure both FMX and VCL notifiers free created controls when destroyed

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849e61db6ec8327887f896a2210b1c1